### PR TITLE
Feat: add webhook based trigger

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -13,5 +13,5 @@ jobs:
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.PAT }}
-          repository: JoE11-y/stone-packaging
+          repository: dipdup-io/stone-packaging
           event-type: prover-update

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -12,6 +12,6 @@ jobs:
       - name: Respository dispatch
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          token: ${{ secrets.PAT }}
           repository: JoE11-y/stone-packaging
           event-type: prover-update

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -13,5 +13,5 @@ jobs:
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          repository: JoE11-y//stone-packaging
+          repository: JoE11-y/stone-packaging
           event-type: prover-update

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,0 +1,17 @@
+name: Dispatch to stone-packaging
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Respository dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          repository: JoE11-y//stone-packaging
+          event-type: prover-update

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Respository dispatch
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           repository: JoE11-y/stone-packaging


### PR DESCRIPTION
This PR addresses https://github.com/dipdup-io/stone-packaging/issues/6 by adding a webhook trigger to the Stone Prover GitHub Action.

Changes
- Added a repository_dispatch trigger to the GitHub Action workflow for stone-prover.

Test Results
- You can view the successful test run [here](https://github.com/JoE11-y/stone-prover/actions/runs/11138069024/job/30952492155).

Integration Steps

To properly integrate this change, follow these steps:
1. Create a Personal Access Token with the workflow scope.
2. Add the token to the repository's secrets with the key name PAT.

This token is required for the workflow to dispatch actions between repositories.